### PR TITLE
Declare support for tvOS

### DIFF
--- a/RaptureXML.podspec
+++ b/RaptureXML.podspec
@@ -6,8 +6,9 @@ Pod::Spec.new do |s|
   s.homepage      = 'https://github.com/ZaBlanc/RaptureXML'
   s.author        = { 'John Blanco' => 'zablanc@gmail.com' }
   s.source        = { :git => 'https://github.com/ZaBlanc/RaptureXML.git', :tag => s.version.to_s }
-  s.platform      = :ios
   s.source_files  = 'RaptureXML/*'
+  s.ios.deployment_target = '7.0'
+  s.tvos.deployment_target = '9.0'
 
   s.libraries     = 'z', 'xml2'
   s.xcconfig      = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }


### PR DESCRIPTION
RaptureXML seems to work just fine on tvOS but cannot be used directly from Cocoapods (without forking) because its podspec declares support for iOS only. This PR adds the appropriate declarations to RaptureXML.podspec declaring support for both iOS and tvOS.
